### PR TITLE
Handle exponential notation

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -25,7 +25,7 @@ var StringifyWithFloats = function StringifyWithFloats() {
       } else {
         value = val;
       }
-      var forceFloat = config[key] === 'float' && (value || value === 0) && typeof value === 'number' && !value.toString().includes('e');
+      var forceFloat = config[key] === 'float' && (value || value === 0) && typeof value === 'number' && !value.toString().toLowerCase().includes('e');
       return forceFloat ? '' + beginFloat + value + endFloat : value;
     };
     var json = JSON.stringify(inputValue, jsonReplacer, space);

--- a/build/index.js
+++ b/build/index.js
@@ -25,7 +25,7 @@ var StringifyWithFloats = function StringifyWithFloats() {
       } else {
         value = val;
       }
-      var forceFloat = config[key] === 'float' && (value || value === 0) && typeof value === 'number';
+      var forceFloat = config[key] === 'float' && (value || value === 0) && typeof value === 'number' && !value.toString().includes('e');
       return forceFloat ? '' + beginFloat + value + endFloat : value;
     };
     var json = JSON.stringify(inputValue, jsonReplacer, space);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "An extended JSON.stringify with the ability to force float data type.",
   "main": "build/index.js",
+  "module": "src/index.js",
   "scripts": {
     "build": "babel src --out-dir build --presets env --plugins add-module-exports",
     "test": "npm run build && ava test"

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const StringifyWithFloats = (config = {}) => (inputValue, inputReplacer, space) 
     const forceFloat = config[key] === 'float'
       && (value || value === 0)
       && typeof value === 'number'
-      && !value.toString().includes('e');
+      && !value.toString().toLowerCase().includes('e');
     return forceFloat ? `${beginFloat}${value}${endFloat}` : value;
   };
   const json = JSON.stringify(inputValue, jsonReplacer, space);

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ const StringifyWithFloats = (config = {}) => (inputValue, inputReplacer, space) 
     }
     const forceFloat = config[key] === 'float'
       && (value || value === 0)
-      && typeof value === 'number';
+      && typeof value === 'number'
+      && !value.toString().includes('e');
     return forceFloat ? `${beginFloat}${value}${endFloat}` : value;
   };
   const json = JSON.stringify(inputValue, jsonReplacer, space);

--- a/test/index.js
+++ b/test/index.js
@@ -97,3 +97,13 @@ test('stringify date', function (t) {
   var expected = '{"a":0.1,"b":"1970-01-01T00:00:00.001Z"}';
   t.is(actual, expected);
 });
+
+test('stringify exponential notation', function (t) {
+  var value = {
+    a: .10,
+    b: 5e-7
+  };
+  var actual = StringifyWithFloats()(value);
+  var expected = '{"a":0.1,"b":5e-7}';
+  t.is(actual, expected);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -100,10 +100,10 @@ test('stringify date', function (t) {
 
 test('stringify exponential notation', function (t) {
   var value = {
-    a: .10,
+    a: 4e-8,
     b: 5e-7
   };
-  var actual = StringifyWithFloats()(value);
-  var expected = '{"a":0.1,"b":5e-7}';
+  var actual = StringifyWithFloats({ b: 'float' })(value);
+  var expected = '{"a":4e-8,"b":5e-7}';
   t.is(actual, expected);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -100,10 +100,12 @@ test('stringify date', function (t) {
 
 test('stringify exponential notation', function (t) {
   var value = {
-    a: 4e-8,
-    b: 5e-7
+    a1: 4E-8,
+    a2: 4e-8,
+    b1: 5E-7,
+    b2: 5e-7
   };
-  var actual = StringifyWithFloats({ b: 'float' })(value);
-  var expected = '{"a":4e-8,"b":5e-7}';
+  var actual = StringifyWithFloats({ b1: 'float', b2: 'float' })(value);
+  var expected = '{"a1":4e-8,"a2":4e-8,"b1":5e-7,"b2":5e-7}';
   t.is(actual, expected);
 });


### PR DESCRIPTION
https://weight-watchers.slack.com/archives/CF819TZV2/p1547487049026200
> We have been working on parsing the food payloads and came across a JSON parsing error. It seems there are a small amount of records that have scientific notation ie `"smartPointsPrecise":5e-7.0`, causing errors to be thrown when trying convert String to a JSON object.
> 
> In python the JSON library works with scientific notation, the issue it seems is the exponent being a float.

Fixes #5